### PR TITLE
Fix issue with handling request types that do not contain request body

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,9 @@
 export default function ({type}) {
   return (req, res, next) => {
-    if (req.is(type)) {
+    const contentTypeIsValid = req.is(type);
+    const requestHasNoBody = contentTypeIsValid === null;
+
+    if (contentTypeIsValid || requestHasNoBody) {
       return next();
     }
     return res.sendStatus(415);

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -14,7 +14,7 @@ describe('index', () => {
     server.close();
   });
 
-  it('Should call next', async () => {
+  it('Should call next: request type matches configuration', async () => {
     const middleware = validateContentType({type: 'application/json'});
     server = startServer(middleware);
 
@@ -29,7 +29,18 @@ describe('index', () => {
     expect(response.status).to.equal(200);
   });
 
-  it('Should set status to 415', async () => {
+  it('Should call next: request does not have body', async () => {
+    const middleware = validateContentType({type: 'application/json'});
+    server = startServer(middleware);
+
+    const response = await fetch(`http://localhost:${HTTP_PORT}`, {
+      method: 'GET'
+    });
+
+    expect(response.status).to.equal(200);
+  });
+
+  it('Should set status to 415: request content type does not match configuration', async () => {
     const middleware = validateContentType({type: 'text/plain'});
     server = startServer(middleware);
 
@@ -43,6 +54,21 @@ describe('index', () => {
 
     expect(response.status).to.equal(415);
   });
+
+  it('Should call next: request content type mismatch with configuration does not matter when request does not contain body', async () => {
+    const middleware = validateContentType({type: 'text/plain'});
+    server = startServer(middleware);
+
+    const response = await fetch(`http://localhost:${HTTP_PORT}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'text/plain'
+      }
+    });
+
+    expect(response.status).to.equal(200);
+  });
+
 });
 
 function startServer(middleware) {


### PR DESCRIPTION
- Allow requests to pass if they do not contain body
- Add new tests

Reasoning for this PR is that if you send a GET request for example without any content-type headers (as in this case they are not mandatory since request does not contain body) the middleware will currently evaluate the null value returned from req.is function as falsy.

Related resources:
- req.is documentation regarding return of null value when there is no request body: https://expressjs.com/en/4x/api.html#req.is
- SO discussion regarding need for content-type header for request types that do not typically contain body: https://stackoverflow.com/q/5661596